### PR TITLE
Add LimeSurvey integration templates

### DIFF
--- a/Limesurvey/with_voice/Limesurvey-with-voice.html
+++ b/Limesurvey/with_voice/Limesurvey-with-voice.html
@@ -1,0 +1,12 @@
+<div style="width: 95%; margin-left: auto; margin-right: auto; min-width: 300px; max-width: 800px; background-color: #fff; display: flex; flex-direction: column; padding: 1px; height: 700px;" class="chat-container">
+    <input type="hidden" id="first_question" name="first_question" />
+    <div style="overflow-y: scroll; height: calc(100% - 200px); margin-bottom: 5px; border: 2px solid #ddd; border-radius: 5px; padding: 10px; display: flex; flex-direction: column; align-items: flex-end;" id="chatArea" class="chat-area">&nbsp;</div>
+    
+    <div style="position: relative; margin-top: 5px;" class="input-container"><textarea style="width: 100%; resize: vertical; font-size: 18px; min-height: 150px; max-height: 150px; border: 2px solid #A9A9A9; border-radius: 10px; padding: 10px; overflow: auto;" placeholder="Type your message here..." maxlength="3000" id="inputBox" class="input-box"></textarea></div>
+    
+    <div style="display: flex; justify-content: flex-end; padding-top: 10px;" class="submit-button-container">
+    <div style="flex-grow: 1; font-size: 18px; border: none; height: 30px; line-height: 1.2; padding-left: 10px; color: rgb(53, 53, 53);">Please write full sentences.</div>
+    <button style="background-color: #D3D3D3; color: black; border: none; padding: 10px 20px; border-radius: 5px; cursor: pointer; font-size: 18px; transition: background-color 0.3s; margin-right: 10px;" id="recordButton" class="record-button">Record response</button>
+    <button style="background-color: #007AC0; color: white; border: none; padding: 10px 20px; border-radius: 5px; cursor: pointer; font-size: 18px; transition: background-color 0.3s;" id="submitButton" class="submit-button">Submit response</button></div>
+</div>
+    

--- a/Limesurvey/with_voice/Limesurvey-with-voice.js
+++ b/Limesurvey/with_voice/Limesurvey-with-voice.js
@@ -1,0 +1,264 @@
+document.addEventListener("DOMContentLoaded", function () {
+        /*Place your JavaScript here to run when the page loads*/
+
+        ////////////////////////////////////////////////////////////////
+        // Key embedded data from the LimeSurvey survey setup        ///
+        ////////////////////////////////////////////////////////////////
+
+        // Instructions: Initialize these variables using LimeSurvey's Expression Manager.
+        var userID = '{user_id}';
+        var interviewID = '{interview_id}';
+    var endpoint = '{interview_endpoint}';
+
+	////////////////////////////////
+    // Key input and output elements
+	////////////////////////////////
+    var chatArea = document.getElementById("chatArea");
+    var submitButton = document.getElementById("submitButton");
+    var inputField = document.getElementById("inputBox");
+
+	////////////////////////////////
+	//// START AUDIO INPUT CODE ////
+	////////////////////////////////	
+	let mediaRecorder;
+	let audioChunks = []; 
+	let stream;
+	const recordButton = document.getElementById("recordButton"); // The record button
+
+	recordButton.addEventListener("click", async () => {
+		if (recordButton.textContent === "Record response") {
+			// Start recording
+			try {
+				stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+				mediaRecorder = new MediaRecorder(stream);
+				audioChunks = []; // Reset the audio chunks
+				recordButton.textContent = "Stop recording";
+                submitButton.disabled = true;
+				mediaRecorder.start();
+				mediaRecorder.ondataavailable = (event) => {
+					audioChunks.push(event.data);
+				};
+			} catch (err) {
+				alert("Error accessing microphone: " + err.message);
+                submitButton.disabled = false;
+			}
+		} else if (recordButton.textContent === "Stop recording") {
+			// Stop recording
+			recordButton.textContent = "Transcribing audio...";
+			recordButton.disabled = true;
+			mediaRecorder.stop();
+			mediaRecorder.onstop = async () => {
+				// Create audio blob in base64 format
+				const audioBlob = new Blob(audioChunks, { type: "audio/webm" });
+				const reader = new FileReader();
+				reader.onloadend = async () => {
+					const audioBase64 = reader.result.split(",")[1]; // Remove the "data:..." prefix
+					const payload = {route: "transcribe", payload: {audio: audioBase64}};
+					// Send audio to the transcribe API endpoint
+					try {
+						jQuery.ajax({
+							url: endpoint,
+							type: "POST",
+							timeout: 60000,
+							data: JSON.stringify(payload),
+							contentType: "application/json",
+							dataType: "json",
+							success: function (data) {
+								const transcript = data.transcription || "Transcription failed. Please try again.";
+								inputField.value = transcript;
+								recordButton.textContent = "Record response";
+                                submitButton.disabled = false;
+							},
+							error: function (jqXHR, textStatus, errorThrown) {
+								console.error("Error:", errorThrown);
+								alert("Something went wrong with the transcription. Please try again.");
+								recordButton.textContent = "Record response";
+                                submitButton.disabled = false;
+							}
+						});
+					} catch (error) {
+						console.error("Communication Error:", error);
+						alert("Error communicating with the API: " + error.message);
+						recordButton.textContent = "Record response";
+					} finally {
+						// Clean up
+						audioChunks = [];
+						recordButton.disabled = false;
+                        submitButton.disabled = false;
+					}
+				};
+
+				reader.readAsDataURL(audioBlob); // Trigger the Base64 encoding
+				stream.getTracks().forEach(track => track.stop()); // Stop microphone access
+			};
+
+		}
+	});
+	////////////////////////////////
+	/// END OF AUDIO INPUT CODE ////
+	////////////////////////////////
+
+	
+	
+
+	///////////////////////////////////////////
+	/// ADD NEW MESSAGES WITH DANCIND DOTS ////
+	///////////////////////////////////////////
+
+    function appendChatbotMessage(message, chatArea, status) {		
+        // New message from the chatbot
+        var messageContent = document.createElement('div');
+        messageContent.style.cssText = "word-wrap: break-word; width: 80%; border: 1px solid #F6F6F6; border-radius: 5px; padding: 5px; margin-bottom: 10px; background-color: #F6F6F6; display: block; margin-right: auto;  font-size: 18px; line-height: 1.5;";
+
+        if (status === "waiting") {
+            // Dancing dots animation
+            messageContent.innerHTML = `
+            <div word-wrap: break-word; width: 80%; border: 1px solid #F6F6F6; border-radius: 5px; padding: 5px; margin-bottom: 10px; background-color: #F6F6F6; display: block; margin-right: auto;>
+            <div id="wave" style="position:relative; vertical-align: center text-align:left"; text-align:center;">
+            <span class="dot" style="display:inline-block; width:12px; height:6px; border-radius:50%; margin-right:3px; background:#303131; animation: wave 1.3s linear infinite;"></span>
+            <span class="dot" style="display:inline-block; width:12px; height:6px; border-radius:50%; margin-right:3px; background:#303131; animation: wave 1.3s linear infinite; animation-delay: -1.1s;"></span>
+            <span class="dot" style="display:inline-block; width:12px; height:6px; border-radius:50%; margin-right:3px; background:#303131; animation: wave 1.3s linear infinite; animation-delay: -0.9s;"></span>
+            </div><style>@keyframes wave {0%, 60%, 100% {transform: initial;} 30% {transform: translateY(-7px);}}</style></div>`;
+            messageContent.id = "dancingDots"; 
+        } else if (status === "response") {
+            var existingDots = document.getElementById("dancingDots");
+            if (existingDots) {
+                existingDots.innerText = message.trim();
+                existingDots.removeAttribute('id');
+                chatArea.scrollTop = chatArea.scrollHeight;
+                return; // Since the message is replaced, we don't need to append anything new
+            } else {
+                messageContent.innerText = message.trim();
+            }
+        }
+        chatArea.appendChild(messageContent);
+        chatArea.scrollTop = chatArea.scrollHeight;
+    }
+
+	
+	////////////////////////////////////////////
+    // GET THE FIRST QUESTION FROM THE SERVER //
+	////////////////////////////////////////////
+    jQuery.ajax({
+        url: endpoint,
+        timeout: 60000,
+        type: "POST",
+        data: JSON.stringify({
+            route: "next",
+            payload: {
+                user_message: "",
+                session_id: userID,
+                interview_id: interviewID
+            }
+        }),
+        contentType: "application/json",
+        dataType: "json",
+        success: function (data) {
+            question = data.message.trim()
+            appendChatbotMessage(question, chatArea, "response");
+            var firstQuestionField = document.getElementById('first_question');
+            if (firstQuestionField) {
+                firstQuestionField.value = question;
+            }
+        },
+        error: function (jqXHR, textStatus, errorThrown) {
+            console.error("Error:", errorThrown);
+            appendChatbotMessage("There was a technical error. Please refresh or proceed in the survey.", chatArea, "response");
+        }
+    });
+
+    
+	////////////////////////////////////////////////////////////
+    // Prevent copy, cut, and paste in chatArea and inputField /
+	////////////////////////////////////////////////////////////
+    ["copy", "cut", "paste"].forEach(eventType => {
+        [chatArea, inputField].forEach(element => {
+            element.addEventListener(eventType, event => {
+                event.preventDefault();
+            });
+        });
+    });
+
+
+	////////////////////////////////////////////////////////////
+    // GENERATE THE NEXT QUESTION ON SUBMIT BUTTON CLICK ///////
+	////////////////////////////////////////////////////////////
+    submitButton.addEventListener("click", function () {
+        var userMessage = inputField.value.trim();
+        // Take action only for non-empty messages.
+        if (userMessage) {
+            // Clear the input field
+            inputField.value = "";
+
+            // Make the submit button unclickable until the chatbot replies
+            submitButton.disabled = true;
+            submitButton.style.backgroundColor = '#ccc';
+            submitButton.innerText = "Waiting for reply...";
+            // Also disable the audio record button.
+			recordButton.disabled = true;
+
+            // Add user message to the chat area
+            var messageContent = document.createElement('div');
+            messageContent.style.cssText = "display: inline-block; max-width: 80%; border: 1px solid #ddd; border-radius: 5px; padding: 5px; margin-bottom: 10px; background-color: #ddd; word-wrap: break-word; white-space: pre-wrap; box-sizing: border-box; font-size: 18px; text-align: left; line-height: 1.5;";
+            messageContent.innerText = userMessage;
+                        
+            // Add label and message of the user to the chat area and scroll to the bottom
+            chatArea.appendChild(messageContent);
+            chatArea.scrollTop = chatArea.scrollHeight;
+
+            // Add dancing dots
+            appendChatbotMessage("", chatArea, "waiting");
+
+            // API CALL: GENERATE THE NEXT QUESTION
+            jQuery.ajax({
+                url: endpoint,
+                timeout: 60000,
+                type: "POST",
+                data: JSON.stringify({
+					route: "next",
+					payload: {
+						user_message: userMessage,
+						session_id: userID,
+						interview_id: interviewID
+					}
+                }),
+                contentType: "application/json",
+                dataType: "json",
+                success: function (data) {
+                    var next_question = data.message.trim();
+
+                    // Check if this is the last message of the interview
+                    var endInterviewIndex = next_question.indexOf("---END---");
+                    if (endInterviewIndex !== -1) {
+                        // End of interview
+                        next_question = next_question.replace("---END---", "");
+                        next_question = next_question.trim();
+                        submitButton.disabled = true;
+                        submitButton.innerText = "End of interview";
+                        // Also disable the audio record button.
+                        recordButton.disabled = true;
+                    } else {
+                        // Interview continues
+                        submitButton.disabled = false;
+                        submitButton.innerText = "Submit response";
+                        submitButton.style.backgroundColor = '#007BFF';
+                        // Re-enable audio record button.
+                        recordButton.disabled = false;
+                    }
+                    appendChatbotMessage(next_question, chatArea, "response");
+                },
+                // REQUEST UNSUCCESSFUL
+                error: function (jqXHR, textStatus, errorThrown) {
+                    console.error("Error:", errorThrown);
+                    appendChatbotMessage("There was a technical error. Please try again.", chatArea, "response");
+                    submitButton.disabled = false;
+                    submitButton.style.backgroundColor = '#007BFF';
+                    submitButton.innerText = "Submit response";
+                    // Also disable the audio record button.
+                    recordButton.disabled = false;
+                }
+            });
+        }
+    });
+    
+});

--- a/Limesurvey/without_voice/Limesurvey.html
+++ b/Limesurvey/without_voice/Limesurvey.html
@@ -1,0 +1,10 @@
+<div style="width: 95%; margin-left: auto; margin-right: auto; min-width: 300px; max-width: 800px; background-color: #fff; display: flex; flex-direction: column; padding: 1px; height: 700px;" class="chat-container">
+    <input type="hidden" id="first_question" name="first_question" />
+    <div style="overflow-y: scroll; height: calc(100% - 200px); margin-bottom: 5px; border: 2px solid #ddd; border-radius: 5px; padding: 10px; display: flex; flex-direction: column; align-items: flex-end;" id="chatArea" class="chat-area">&nbsp;</div>
+    
+    <div style="position: relative; margin-top: 5px;" class="input-container"><textarea style="width: 100%; resize: vertical; font-size: 18px; min-height: 150px; max-height: 150px; border: 2px solid #A9A9A9; border-radius: 10px; padding: 10px; overflow: auto;" placeholder="Type your message here..." maxlength="3000" id="inputBox" class="input-box"></textarea></div>
+    
+    <div style="display: flex; justify-content: flex-end; padding-top: 10px;" class="submit-button-container">
+    <div style="flex-grow: 1; font-size: 18px; border: none; height: 30px; line-height: 1.2; padding-left: 10px; color: rgb(53, 53, 53);">Please write full sentences.</div>
+    <button style="background-color: #007AC0; color: white; border: none; padding: 10px 20px; border-radius: 5px; cursor: pointer; font-size: 18px; transition: background-color 0.3s;" id="submitButton" class="submit-button">Submit response</button></div>
+</div>

--- a/Limesurvey/without_voice/Limesurvey.js
+++ b/Limesurvey/without_voice/Limesurvey.js
@@ -1,0 +1,172 @@
+document.addEventListener("DOMContentLoaded", function () {
+        /*Place your JavaScript here to run when the page loads*/
+
+        ////////////////////////////////////////////////////////////////
+        // Key embedded data from the LimeSurvey survey setup        ///
+        ////////////////////////////////////////////////////////////////
+
+        // Instructions: Initialize these variables using LimeSurvey's Expression Manager.
+        var userID = '{user_id}';
+        var interviewID = '{interview_id}';
+    var endpoint = '{interview_endpoint}';
+
+	////////////////////////////////
+    // Key input and output elements
+	////////////////////////////////
+    var chatArea = document.getElementById("chatArea");
+    var submitButton = document.getElementById("submitButton");
+    var inputField = document.getElementById("inputBox");
+
+	///////////////////////////////////////////
+	/// ADD NEW MESSAGES WITH DANCIND DOTS ////
+	///////////////////////////////////////////
+
+    function appendChatbotMessage(message, chatArea, status) {		
+        // New message from the chatbot
+        var messageContent = document.createElement('div');
+        messageContent.style.cssText = "word-wrap: break-word; width: 80%; border: 1px solid #F6F6F6; border-radius: 5px; padding: 5px; margin-bottom: 10px; background-color: #F6F6F6; display: block; margin-right: auto;  font-size: 18px; line-height: 1.5;";
+
+        if (status === "waiting") {
+            // Dancing dots animation
+            messageContent.innerHTML = `
+            <div word-wrap: break-word; width: 80%; border: 1px solid #F6F6F6; border-radius: 5px; padding: 5px; margin-bottom: 10px; background-color: #F6F6F6; display: block; margin-right: auto;>
+            <div id="wave" style="position:relative; vertical-align: center text-align:left"; text-align:center;">
+            <span class="dot" style="display:inline-block; width:12px; height:6px; border-radius:50%; margin-right:3px; background:#303131; animation: wave 1.3s linear infinite;"></span>
+            <span class="dot" style="display:inline-block; width:12px; height:6px; border-radius:50%; margin-right:3px; background:#303131; animation: wave 1.3s linear infinite; animation-delay: -1.1s;"></span>
+            <span class="dot" style="display:inline-block; width:12px; height:6px; border-radius:50%; margin-right:3px; background:#303131; animation: wave 1.3s linear infinite; animation-delay: -0.9s;"></span>
+            </div><style>@keyframes wave {0%, 60%, 100% {transform: initial;} 30% {transform: translateY(-7px);}}</style></div>`;
+            messageContent.id = "dancingDots"; 
+        } else if (status === "response") {
+            var existingDots = document.getElementById("dancingDots");
+            if (existingDots) {
+                existingDots.innerText = message.trim();
+                existingDots.removeAttribute('id');
+                chatArea.scrollTop = chatArea.scrollHeight;
+                return; // Since the message is replaced, we don't need to append anything new
+            } else {
+                messageContent.innerText = message.trim();
+            }
+        }
+        chatArea.appendChild(messageContent);
+        chatArea.scrollTop = chatArea.scrollHeight;
+    }
+
+	
+	////////////////////////////////////////////
+    // GET THE FIRST QUESTION FROM THE SERVER //
+	////////////////////////////////////////////
+    jQuery.ajax({
+        url: endpoint,
+        timeout: 60000,
+        type: "POST",
+        data: JSON.stringify({
+            route: "next",
+            payload: {
+                user_message: "",
+                session_id: userID,
+                interview_id: interviewID
+            }
+        }),
+        contentType: "application/json",
+        dataType: "json",
+        success: function (data) {
+            question = data.message.trim()
+            appendChatbotMessage(question, chatArea, "response");
+            var firstQuestionField = document.getElementById('first_question');
+            if (firstQuestionField) {
+                firstQuestionField.value = question;
+            }
+        },
+        error: function (jqXHR, textStatus, errorThrown) {
+            console.error("Error:", errorThrown);
+            appendChatbotMessage("There was a technical error. Please refresh or proceed in the survey.", chatArea, "response");
+        }
+    });
+
+    
+	////////////////////////////////////////////////////////////
+    // Prevent copy, cut, and paste in chatArea and inputField /
+	////////////////////////////////////////////////////////////
+    ["copy", "cut", "paste"].forEach(eventType => {
+        [chatArea, inputField].forEach(element => {
+            element.addEventListener(eventType, event => {
+                event.preventDefault();
+            });
+        });
+    });
+
+
+	////////////////////////////////////////////////////////////
+    // GENERATE THE NEXT QUESTION ON SUBMIT BUTTON CLICK ///////
+	////////////////////////////////////////////////////////////
+    submitButton.addEventListener("click", function () {
+        var userMessage = inputField.value.trim();
+        // Take action only for non-empty messages.
+        if (userMessage) {
+            // Clear the input field
+            inputField.value = "";
+
+            // Make the submit button unclickable until the chatbot replies
+            submitButton.disabled = true;
+            submitButton.style.backgroundColor = '#ccc';
+            submitButton.innerText = "Waiting for reply...";
+
+            // Add user message to the chat area
+            var messageContent = document.createElement('div');
+            messageContent.style.cssText = "display: inline-block; max-width: 80%; border: 1px solid #ddd; border-radius: 5px; padding: 5px; margin-bottom: 10px; background-color: #ddd; word-wrap: break-word; white-space: pre-wrap; box-sizing: border-box; font-size: 18px; text-align: left; line-height: 1.5;";
+            messageContent.innerText = userMessage;
+                        
+            // Add label and message of the user to the chat area and scroll to the bottom
+            chatArea.appendChild(messageContent);
+            chatArea.scrollTop = chatArea.scrollHeight;
+
+            // Add dancing dots
+            appendChatbotMessage("", chatArea, "waiting");
+
+            // API CALL: GENERATE THE NEXT QUESTION
+            jQuery.ajax({
+                url: endpoint,
+                timeout: 60000,
+                type: "POST",
+                data: JSON.stringify({
+					route: "next",
+					payload: {
+						user_message: userMessage,
+						session_id: userID,
+						interview_id: interviewID
+					}
+                }),
+                contentType: "application/json",
+                dataType: "json",
+                success: function (data) {
+                    var next_question = data.message.trim();
+
+                    // Check if this is the last message of the interview
+                    var endInterviewIndex = next_question.indexOf("---END---");
+                    if (endInterviewIndex !== -1) {
+                        // End of interview
+                        next_question = next_question.replace("---END---", "");
+                        next_question = next_question.trim();
+                        submitButton.disabled = true;
+                        submitButton.innerText = "End of interview";
+                    } else {
+                        // Interview continues
+                        submitButton.disabled = false;
+                        submitButton.innerText = "Submit response";
+                        submitButton.style.backgroundColor = '#007BFF';
+                    }
+                    appendChatbotMessage(next_question, chatArea, "response");
+                },
+                // REQUEST UNSUCCESSFUL
+                error: function (jqXHR, textStatus, errorThrown) {
+                    console.error("Error:", errorThrown);
+                    appendChatbotMessage("There was a technical error. Please try again.", chatArea, "response");
+                    submitButton.disabled = false;
+                    submitButton.style.backgroundColor = '#007BFF';
+                    submitButton.innerText = "Submit response";
+                }
+            });
+        }
+    });
+    
+});

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ For inquiries about commercial licenses, please contact [Felix Chopra](f.chopra@
 * [Option 2: Deploy as Flask app](#option-2-deploy-as-flask-app)
 * [Option 3: Deploy as AWS Lambda function (preferred)](#option-3-deploy-on-aws)
 * [Qualtrics integration](#integrating-with-qualtrics)
+* [Limesurvey integration](#limesurvey-integration)
 * [How to interact with the app](#how-to-interact-with-the-app)
 * [Retrieving stored interviews](#retrieving)
 
@@ -180,6 +181,16 @@ Once you have deployed your app, you can integrate it (using the public endpoint
 **Step 1:** In Qualtrics, add embedded variables `user_id`, `interview_id`, `interview_endpoint` and `first_question` to the begining of your survey flow. `user_id` should uniquely identify your respondent. `interview_id` should identify the parameter settings of your AI interviewer (see `app/parameters.py` for details, e.g. `STOCK_MARKET`). `interview_endpoint` is the URL of the public endpoint of your hosted application.
 
 **Step 2:** Create a `Text/Graphic` question in your survey. The folders `Qualtrics` contain HTML and JavaScript files depending on whether you would like to allow respondents to provide audio input or only written input. Copy the content into the HTML and JavaScript field of the `Text/Graphic` question.
+
+**Step 3:** Done!
+
+## Limesurvey integration
+
+Once you have deployed your app, you can integrate it into a Limesurvey questionnaire.
+
+**Step 1:** In Limesurvey, create survey variables `user_id`, `interview_id`, `interview_endpoint`, and `first_question`. These can be stored in hidden questions or set using the Expression Manager. `user_id` should uniquely identify your respondent. `interview_id` selects the interviewer parameters (see `app/parameters.py`, e.g. `STOCK_MARKET`). `interview_endpoint` is the URL of the public endpoint of your hosted application.
+
+**Step 2:** Add a "Text display" question. The folders `Limesurvey` contain HTML and JavaScript files depending on whether you would like to allow respondents to provide audio input or only written input. Copy the content into the question's HTML and JavaScript fields.
 
 **Step 3:** Done!
 


### PR DESCRIPTION
## Summary
- add HTML/JS templates for embedding the interviewer into LimeSurvey with or without voice input
- document LimeSurvey setup steps in the README

## Testing
- `pytest`
- `node --check Limesurvey/without_voice/Limesurvey.js`
- `node --check Limesurvey/with_voice/Limesurvey-with-voice.js`


------
https://chatgpt.com/codex/tasks/task_e_68a748b807e883239197b87de105ef87